### PR TITLE
feat: 비밀번호 재설정 기능 구현

### DIFF
--- a/src/api/auth/index.ts
+++ b/src/api/auth/index.ts
@@ -1,5 +1,6 @@
 import api from '@/plugins/AxiosInterceptor'
 import type { EmailForm } from '@/types/user/Email'
+import type { PasswordChange } from '@/types/user/UserUpdateForm'
 
 /**
  * 이메일 인증 코드 전송 api
@@ -78,8 +79,31 @@ const sendPasswordResetLink = async (req: EmailForm): Promise<ApiResponse> => {
   return data
 }
 
+const resetPassword = async (req: PasswordChange): Promise<ApiResponse> => {
+  let data: ApiResponse = {
+    success: false,
+    code: 0,
+    message: '',
+    results: undefined,
+  }
+
+  const url = '/api/auth/reset-password'
+
+  await api
+    .post(url, req)
+    .then((res) => {
+      data = res.data as ApiResponse
+    })
+    .catch((error) => {
+      data = error.response.data as ApiResponse
+    })
+
+  return data
+}
+
 export default {
   sendAuthCodeToEmail,
   verifyEmailCode,
   sendPasswordResetLink,
+  resetPassword,
 }

--- a/src/api/auth/index.ts
+++ b/src/api/auth/index.ts
@@ -1,4 +1,5 @@
 import api from '@/plugins/AxiosInterceptor'
+import type { EmailForm } from '@/types/user/Email'
 
 /**
  * 이메일 인증 코드 전송 api
@@ -55,7 +56,30 @@ const verifyEmailCode = async (req: { email: string; code: string }): Promise<Ap
   return data
 }
 
+const sendPasswordResetLink = async (req: EmailForm): Promise<ApiResponse> => {
+  let data: ApiResponse = {
+    success: false,
+    code: 0,
+    message: '',
+    results: undefined,
+  }
+
+  const url: string = '/api/auth/find-password/link'
+
+  await api
+    .post(url, req)
+    .then((res) => {
+      data = res.data
+    })
+    .catch((error) => {
+      data = error.response.data as ApiResponse
+    })
+
+  return data
+}
+
 export default {
   sendAuthCodeToEmail,
   verifyEmailCode,
+  sendPasswordResetLink,
 }

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -20,6 +20,11 @@ const router = createRouter({
       component: () => import('@/views/auth/LoginView.vue'),
     },
     {
+      path: '/password-reset',
+      name: 'password-reset',
+      component: () => import('@/views/auth/PasswordFindView.vue'),
+    },
+    {
       path: '/recruiter',
       name: 'main',
       component: () => import('@/views/layout/DashboardLayout.vue'),

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -25,6 +25,14 @@ const router = createRouter({
       component: () => import('@/views/auth/PasswordFindView.vue'),
     },
     {
+      path: '/reset-password',
+      name: 'reset-password',
+      component: () => import('@/views/auth/PasswordResetView.vue'),
+      meta: {
+        requiresToken: true,
+      },
+    },
+    {
       path: '/recruiter',
       name: 'main',
       component: () => import('@/views/layout/DashboardLayout.vue'),
@@ -95,6 +103,20 @@ const router = createRouter({
       ],
     },
   ],
+})
+
+router.beforeEach((to, from, next) => {
+  const requiresToken = to.matched.some((record) => record.meta.requiresToken)
+
+  // 비밀번호 재설정 페이지에서는 토큰이 필요
+  if (requiresToken) {
+    const token = to.query.token
+    if (!token) {
+      next('/login')
+    }
+  }
+
+  next()
 })
 
 export default router

--- a/src/types/user/Email.ts
+++ b/src/types/user/Email.ts
@@ -1,0 +1,7 @@
+export interface EmailForm {
+  email: string
+}
+
+export interface EmailFormErrors {
+  email: string
+}

--- a/src/types/user/UserUpdateForm.ts
+++ b/src/types/user/UserUpdateForm.ts
@@ -1,0 +1,10 @@
+export interface PasswordChange {
+  password: string
+  token: string | undefined
+}
+
+export interface PasswordChangeErrors {
+  password: string
+  passwordConfirm: string
+  global: string
+}

--- a/src/views/auth/LoginView.vue
+++ b/src/views/auth/LoginView.vue
@@ -134,7 +134,7 @@ const handleSubmit = async () => {
                             <a class="text-slate-600 hover:text-slate-700 font-semibold">이메일 찾기</a>
                         </RouterLink>
                         |
-                        <RouterLink>
+                        <RouterLink :to="{ path: 'password-reset' }">
                             <a class="text-slate-600 hover:text-slate-700 font-semibold">비밀번호 찾기</a>
                         </RouterLink>
                     </p>

--- a/src/views/auth/PasswordFindView.vue
+++ b/src/views/auth/PasswordFindView.vue
@@ -1,0 +1,127 @@
+<script setup lang="ts">
+import { ref, reactive } from 'vue'
+import authAPI from '@/api/auth'
+import { UserRound, Mail } from 'lucide-vue-next'
+import type { EmailForm, EmailFormErrors } from '@/types/user/Email'
+
+const emailForm: EmailForm = reactive({
+    email: '',
+})
+
+const initialErrors: EmailFormErrors = reactive({
+    email: '',
+})
+
+const isSendEmail = ref(false)
+
+const errors: EmailFormErrors = reactive({ ...initialErrors })
+
+// 이메일 인증 관련
+const verificationSent = ref(false)
+const emailVerified = ref(false)
+
+const sendPasswordResetLink = async () => {
+
+    if (validateForm()) {
+        const response: ApiResponse = await authAPI.sendPasswordResetLink({ email: emailForm.email })
+        if (response.success) {
+            isSendEmail.value = true
+        } else {
+            alert(response.message);
+        }
+    }
+}
+
+const validateForm = () => {
+
+    Object.assign(errors, initialErrors) // 에러 초기화
+
+    let valid: boolean = true
+
+    if (!emailForm.email.trim()) {
+        errors.email = '이메일을 입력해주세요'
+        valid = false
+    } else if (!/\S+@\S+\.\S+/.test(emailForm.email)) {
+        errors.email = '올바른 이메일 형식이 아닙니다'
+        valid = false
+    }
+
+    return valid
+}
+
+</script>
+<template>
+    <div
+        class="min-h-screen bg-gradient-to-br from-slate-50 via-white to-slate-100 flex items-center justify-center p-4 py-12">
+        <div class="max-w-md w-full">
+            <div class="bg-white rounded-2xl shadow-xl p-8">
+                <!-- 헤더 -->
+                <div class="text-center mb-8">
+                    <div class="inline-flex items-center justify-center w-16 h-16 bg-slate-600 rounded-full mb-4">
+                        <UserRound class="w-8 h-8 text-white" />
+                    </div>
+                    <h1 class="text-3xl font-bold text-gray-900 mb-2">비밀번호 찾기</h1>
+                </div>
+
+                <!-- 폼 -->
+                <form @submit.prevent="sendPasswordResetLink" class="space-y-5">
+
+                    <!-- 이메일 입력 및 인증 -->
+                    <div v-if="!isSendEmail">
+                        <label class="block text-sm font-medium text-gray-700 mb-2">이메일</label>
+                        <div class="flex gap-2">
+                            <div class="relative flex-1">
+                                <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                                    <Mail class="w-5 h-5 text-gray-400" />
+                                </div>
+                                <input v-model="emailForm.email" type="email" :disabled="emailVerified"
+                                    :class="['block w-full pl-10 pr-3 py-3 border rounded-lg focus:ring-2 focus:ring-slate-500 focus:border-transparent transition', errors.email ? 'border-red-300' : emailVerified ? 'border-green-300 bg-green-50' : 'border-gray-300']"
+                                    placeholder="example@email.com" />
+                            </div>
+
+                        </div>
+                        <p v-if="errors.email" class="mt-1 text-sm text-red-600">{{ errors.email }}</p>
+                        <p v-if="verificationSent && !emailVerified" class="mt-1 text-sm text-slate-600">인증번호가 발송되었습니다
+                        </p>
+                    </div>
+                    <div v-else class="text-center">
+                        <p class="text-2xl font-bold">
+                            비밀번호 재설정 링크 전송 완료
+                        </p>
+                        <p>
+                            이메일로 전송된 링크를 확인해주세요.
+                        </p>
+                    </div>
+
+                    <!-- 가입 버튼 -->
+                    <div class="flex gap-2 flex-col">
+                        <button type="button" @click="sendPasswordResetLink"
+                            :disabled="!emailForm.email || verificationSent"
+                            class="w-full bg-slate-600 text-white py-3 rounded-lg font-semibold hover:bg-slate-700 transform hover:scale-[1.02] transition shadow-lg hover:cursor-pointer"
+                            v-if="!isSendEmail">
+                            요청
+                        </button>
+                        <div class="flex gap-2 justify-between" v-else>
+                            <p class="text-slate-400">
+                                링크를 받지 못하셨나요?
+                            </p>
+                            <button class="hover:cursor-pointer text-slate-600" @click="sendPasswordResetLink">
+                                재전송
+                            </button>
+                        </div>
+
+                        <!-- 가입 버튼 -->
+                        <RouterLink :to="{ path: '/login' }">
+                            <button type="submit"
+                                class="w-full border-slate-600 py-3 rounded-lg font-semibold border transform hover:scale-[1.02] transition shadow-md hover:cursor-pointer">
+                                돌아가기
+                            </button>
+                        </RouterLink>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</template>
+
+<style scoped></style>

--- a/src/views/auth/PasswordResetView.vue
+++ b/src/views/auth/PasswordResetView.vue
@@ -1,0 +1,145 @@
+<script setup lang="ts">
+import { ref, reactive, type Ref } from 'vue'
+import authAPI from '@/api/auth'
+import { UserRound, LockKeyhole, Eye, EyeOff } from 'lucide-vue-next'
+import router from '@/router'
+import type { PasswordChange, PasswordChangeErrors } from '@/types/user/UserUpdateForm'
+import { useRoute } from 'vue-router'
+
+const route = useRoute();
+
+const formData: PasswordChange = reactive({
+    password: '',
+    token: route.query.token?.toString()
+})
+
+
+const confirmPassword: Ref<string> = ref('')
+
+const showPassword = ref(false)
+const showConfirmPassword = ref(false)
+
+const initialErrors: PasswordChangeErrors = reactive({
+    password: '',
+    passwordConfirm: '',
+    global: ''
+})
+
+const errors: PasswordChangeErrors = reactive({ ...initialErrors })
+
+const validateForm = () => {
+
+    Object.assign(errors, initialErrors) // 에러 초기화
+
+    let valid: boolean = true
+
+    if (!formData.password) {
+        errors.password = '비밀번호를 입력해주세요'
+        valid = false
+    } else if (formData.password.length < 8) {
+        errors.password = '비밀번호는 8자 이상이어야 합니다'
+        valid = false
+    }
+
+    if (formData.password !== confirmPassword.value) {
+        errors.passwordConfirm = '비밀번호가 일치하지 않습니다'
+        valid = false
+    }
+
+    return valid
+}
+
+/**
+ * 비밀번호 재설정 요청
+ */
+const handleSubmit = async () => {
+
+    if (validateForm()) {
+
+        // 응답 처리
+        const response = await authAPI.resetPassword(formData)
+        if (response.success) {
+
+            alert('비밀번호 재설정 성공! 로그인 화면으로 이동합니다!')
+            router.push({ path: '/login' })
+
+        } else {
+            errors.global = "비밀번호 설정 세션이 만료되었습니다."
+        }
+    }
+}
+</script>
+
+<template>
+    <div
+        class="min-h-screen bg-gradient-to-br from-slate-50 via-white to-slate-100 flex items-center justify-center p-4 py-12">
+        <div class="max-w-md w-full">
+            <div class="bg-white rounded-2xl shadow-xl p-8">
+                <!-- 헤더 -->
+                <div class="text-center mb-8">
+                    <div class="inline-flex items-center justify-center w-16 h-16 bg-slate-600 rounded-full mb-4">
+                        <UserRound class="w-8 h-8 text-white" />
+                    </div>
+                    <h1 class="text-3xl font-bold text-gray-900 mb-2">비밀번호 재설정</h1>
+                </div>
+
+                <!-- 폼 -->
+                <form @submit.prevent="handleSubmit" class="space-y-5">
+
+                    <!-- 비밀번호 입력 -->
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 mb-2">비밀번호</label>
+                        <div class="relative">
+                            <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                                <LockKeyhole class="w-5 h-5 text-gray-400" />
+                            </div>
+                            <input v-model="formData.password" :type="showPassword ? 'text' : 'password'"
+                                :class="['block w-full pl-10 pr-10 py-3 border rounded-lg focus:ring-2 focus:ring-slate-500 focus:border-transparent transition', errors.password || errors.global ? 'border-red-300' : 'border-gray-300']"
+                                placeholder="8자 이상 입력" />
+                            <button type="button" @click="showPassword = !showPassword"
+                                class="absolute inset-y-0 right-0 pr-3 flex items-center">
+
+                                <EyeOff v-if="showPassword" class="h-5 w-5 text-gray-400 hover:text-gray-600" />
+                                <Eye v-else class="h-5 w-5 text-gray-400 hover:text-gray-600" />
+
+                            </button>
+                        </div>
+                        <p v-if="errors.password" class="mt-1 text-sm text-red-600">{{ errors.password }}</p>
+                    </div>
+
+                    <!-- 비밀번호 확인 -->
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 mb-2">비밀번호 확인</label>
+                        <div class="relative">
+                            <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                                <LockKeyhole class="w-5 h-5 text-gray-400" />
+                            </div>
+                            <input v-model="confirmPassword" :type="showConfirmPassword ? 'text' : 'password'" :class="['block w-full pl-10 pr-10 py-3 border rounded-lg focus:ring-2 focus:ring-slate-500 focus:border-transparent transition',
+                                errors.passwordConfirm || errors.global ? 'border-red-300' : 'border-gray-300']"
+                                placeholder="비밀번호 재입력" />
+                            <button type="button" @click="showConfirmPassword = !showConfirmPassword"
+                                class="absolute inset-y-0 right-0 pr-3 flex items-center">
+                                <EyeOff v-if="showConfirmPassword" class="h-5 w-5 text-gray-400 hover:text-gray-600" />
+                                <Eye v-else class="h-5 w-5 text-gray-400 hover:text-gray-600" />
+                            </button>
+                        </div>
+                        <p v-if="errors.passwordConfirm" class="mt-1 text-sm text-red-600">{{ errors.passwordConfirm }}
+                        </p>
+                    </div>
+
+                    <div class="text-center">
+                        <p v-if="errors.global" class="text-sm text-red-600">{{ errors.global }}</p>
+                    </div>
+
+                    <!-- 확인 버튼 -->
+                    <button type="submit"
+                        class="w-full bg-slate-600 text-white py-3 rounded-lg font-semibold hover:bg-slate-700 transform hover:scale-[1.02] transition shadow-lg">
+                        확인
+                    </button>
+                </form>
+            </div>
+        </div>
+    </div>
+</template>
+
+<style scoped></style>


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) closes #이슈번호, closes #이슈번호
> 
> closes를 앞에 붙여주면 PR이 병합될 때 자동으로 해당 이슈가 closed 돼요!

closes #48

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

* 비밀번호를 변경할 수 있는 링크를 이메일로 전송하는 기능 구현
* 받은 이메일에 담긴 링크를 클릭시 비밀번호 재설정 페이지로 이동
* 비밀번호 재설정 페이지는 토큰이 존재해야 접근가능하도록 보안 강화

### 스크린샷 (선택)


1. 비밀번호 링크 전송을 위한 이메일 입력
<img width="621" height="553" alt="image" src="https://github.com/user-attachments/assets/651c8d28-78a6-487c-9e5e-6f4404d5f9f3" />

2. 링크 전송 성공 화면
<img width="582" height="526" alt="image" src="https://github.com/user-attachments/assets/dc01c325-5c92-4727-b1a9-6a9d72328a01" />

3. 이메일로 전송된 링크 내용
<img width="1104" height="368" alt="image" src="https://github.com/user-attachments/assets/4754b0e5-3ede-4c62-8704-a7b5a4b2c0a7" />

4. 링크 클릭시 접속되는 비밀번호 재설정 페이지
<img width="640" height="639" alt="image" src="https://github.com/user-attachments/assets/5363505a-9abb-4580-8751-b3da05e0ad43" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
