### PR TITLE
Fix/#124 password find

### DIFF
--- a/src/types/user/UserUpdateForm.ts
+++ b/src/types/user/UserUpdateForm.ts
@@ -1,4 +1,5 @@
 export interface PasswordChange {
+  email: string | undefined
   password: string
   token: string | undefined
 }

--- a/src/views/auth/PasswordFindView.vue
+++ b/src/views/auth/PasswordFindView.vue
@@ -95,8 +95,7 @@ const validateForm = () => {
 
                     <!-- 버튼 -->
                     <div class="flex gap-2 flex-col">
-                        <button type="submit" @click="sendPasswordResetLink"
-                            :disabled="!emailForm.email || verificationSent"
+                        <button type="submit" :disabled="!emailForm.email || verificationSent"
                             class="w-full bg-slate-600 text-white py-3 rounded-lg font-semibold hover:bg-slate-700 transform hover:scale-[1.02] transition shadow-lg hover:cursor-pointer"
                             v-if="!isSendEmail">
                             요청
@@ -105,7 +104,7 @@ const validateForm = () => {
                             <p class="text-slate-400">
                                 링크를 받지 못하셨나요?
                             </p>
-                            <button class="hover:cursor-pointer text-slate-600" @click="sendPasswordResetLink">
+                            <button class="hover:cursor-pointer text-slate-600" type="submit">
                                 재전송
                             </button>
                         </div>

--- a/src/views/auth/PasswordResetView.vue
+++ b/src/views/auth/PasswordResetView.vue
@@ -9,6 +9,7 @@ import { useRoute } from 'vue-router'
 const route = useRoute();
 
 const formData: PasswordChange = reactive({
+    email: route.query.email?.toString(),
     password: '',
     token: route.query.token?.toString()
 })


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) closes #이슈번호, closes #이슈번호
> 
> closes를 앞에 붙여주면 PR이 병합될 때 자동으로 해당 이슈가 closed 돼요!

- closes #124 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

* 비밀번호 변경 요청 시 이메일을 서버로 전달 할 수 없었던 문제를 해결하였습니다.
* 서버가 링크 변경 URL에 파라미터로 담은 email을 사용하여 서버로 비밀번호 재요청을 수행하도록 수정하였습니다.
* 이메일 요청 시 두번 요청되는 버그를 해결하였습니다.

### 스크린샷 (선택)


![비밀번호 찾기](https://github.com/user-attachments/assets/f971d8aa-91e2-4f2c-9fda-7900c8baa3fe)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
