### PR TITLE
feat: 채용공고 삭제 DB연동

### DIFF
--- a/src/api/jobposting/index.ts
+++ b/src/api/jobposting/index.ts
@@ -234,3 +234,27 @@ export const getCoverLetterTitles = async (jobPostingId: number): Promise<ApiRes
 
   return data
 }
+
+export const deleteJobPosting = async (id: number): Promise<ApiResponse> => {
+  let data: ApiResponse = {
+    success: false,
+    code: 0,
+    message: '',
+    results: undefined,
+  }
+
+  const url = `/api/job-postings/${id}`
+
+  await api
+    .delete(url)
+    .then((res) => {
+      console.log(res)
+      data = res.data
+    })
+    .catch((error) => {
+      console.log(error)
+      data = error.response.data as ApiResponse
+    })
+
+  return data
+}

--- a/src/components/JobHeader.vue
+++ b/src/components/JobHeader.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
 import { useRoute, RouterLink, useRouter } from 'vue-router'
-import { getHeaderById } from '@/api/jobposting/index'
+import { getHeaderById, deleteJobPosting } from '@/api/jobposting/index'
 import { Building2, MapPin, Briefcase, DollarSign, Share2 } from 'lucide-vue-next'
 
 // -----------------------------
@@ -52,6 +52,21 @@ onMounted(async () => {
     isLoading.value = false
   }
 })
+
+const deleteJobPostingHandler = async () => {
+  try {
+    const response = await deleteJobPosting(jobId)
+
+    if (response.success) {
+      alert('공고가 삭제되었습니다')
+      router.push('/admin/jobs')
+    } else {
+      alert(response.message)
+    }
+  } catch (error) {
+    alert('서버 오류')
+  }
+}
 
 // -----------------------------
 // UI 관련 유틸
@@ -189,7 +204,7 @@ const goToEditPage = () => {
               class="w-full px-4 py-3 bg-white text-slate-600 border border-gray-300 rounded-lg hover:bg-gray-50 transition text-sm font-medium">
               모집 중단
             </button>
-            <button
+            <button @click="deleteJobPostingHandler"
               class="w-full px-4 py-3 bg-red-50 text-red-700 border border-red-200 rounded-lg hover:bg-red-100 transition text-sm font-medium">
               공고 삭제
             </button>


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) closes #이슈번호, closes #이슈번호
> 
> closes를 앞에 붙여주면 PR이 병합될 때 자동으로 해당 이슈가 closed 돼요!
- closes #172 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
채용공고 삭제에 대한 DB연동 기능 구현(접수기간 이외에만 삭제되도록 설정)

### 스크린샷
![채용공고 삭제](https://github.com/user-attachments/assets/675d30ae-1257-4ecf-b603-af706f7c0a1d)
 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
