### PR TITLE
fix: 채용프로세스 color 선택

### DIFF
--- a/src/views/jobposting/JobForm.vue
+++ b/src/views/jobposting/JobForm.vue
@@ -98,6 +98,8 @@ const stages = ref<StageEdit[]>([
   { id: 3, name: '2차 면접', color: 'PURPLE', edit: false },
 ])
 
+const baseColors = ['BLUE', 'ORANGE', 'PINK', 'PURPLE', 'RED']
+
 const syncRecruitProcess = () => {
   const middle = stages.value.map((s, idx) => ({
     id: idx + 1,


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) closes #이슈번호, closes #이슈번호
> 
> closes를 앞에 붙여주면 PR이 병합될 때 자동으로 해당 이슈가 closed 돼요!

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
수정하는 과정에서 채용공고 등록시 채용프로세스별 컬러 지정하는 부분이 누락되서 수정

### 스크린샷 (선택)
before
<img width="1797" height="948" alt="image" src="https://github.com/user-attachments/assets/9eb94978-ceb6-4bee-b825-a4275f6db9a0" />

after
<img width="1832" height="971" alt="image" src="https://github.com/user-attachments/assets/90d355ba-8768-4f56-ab0e-abdfe285fb03" />



## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
