### PR TITLE
fix: api 수정

### DIFF
--- a/src/api/publicjobposting/index.ts
+++ b/src/api/publicjobposting/index.ts
@@ -13,7 +13,15 @@ export const searchPublicJobs = async (payload: PublicJobSearchRequest): Promise
   const url = '/api/jobs/search'
 
   await api
-    .post(url, payload)
+    .get(url, {
+      params: {
+        page: payload.page,
+        size: payload.size,
+        keyword: payload.keyword || null,
+        careerType: payload.careerType || null,
+        techStack: payload.techStack || null,
+      },
+    })
     .then((res) => {
       console.log(res)
       data = res.data

--- a/src/views/jobposting/JobList.vue
+++ b/src/views/jobposting/JobList.vue
@@ -46,9 +46,9 @@ const size = 12
 // 📌 Payload builder
 // =============================
 const buildPayload = () => ({
-  keyword: keyword.value || undefined,
-  careerType: careerType.value || undefined,
-  techStacks: techStacks.value.length ? techStacks.value : undefined,
+  keyword: keyword.value || null,
+  careerType: careerType.value || null,
+  techStack: singleTech.value || null,  // 단일 기술스택
   page: page.value,
   size
 })
@@ -83,13 +83,6 @@ const loadJobs = async () => {
 // 📌 검색 버튼 클릭
 // =============================
 const onSearch = () => {
-  // 단일 선택을 배열 형태로 변환
-  techStacks.value = []
-  if (singleTech.value) {
-    techStacks.value.push(singleTech.value)
-  }
-
-  // 페이지 초기화 후 검색
   page.value = 0
   hasMore.value = true
   loadJobs()
@@ -193,9 +186,9 @@ onMounted(() => {
           <select v-model="careerType" class="w-full h-14 px-4 rounded-lg bg-gray-100 border border-gray-200
                text-slate-700 focus:bg-white focus:ring-2 focus:ring-slate-400 transition">
             <option :value="null">전체</option>
-            <option value="신입">신입</option>
-            <option value="경력">경력</option>
-            <option value="경력무관">무관</option>
+            <option value="NEW">신입</option>
+            <option value="EXPERIENCED">경력</option>
+            <option value="ANY">무관</option>
           </select>
         </div>
 


### PR DESCRIPTION
채용공고 조회시 post로 요청 보내던 것을 get으로 수정

## #️⃣연관된 이슈

> ex) closes #이슈번호, closes #이슈번호
> 
> closes를 앞에 붙여주면 PR이 병합될 때 자동으로 해당 이슈가 closed 돼요!
- closes #192 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
지원자가 보는 전체채용공고 요청 api를 post -> get으로 변경합니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
